### PR TITLE
run service-homeassistant container in un-privileged mode by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,6 @@ init:
 run: stop
 	@docker run -d \
 		--name $(DOCKER_IMAGE_NAME) \
-		--privileged \
 		--restart=unless-stopped \
 		-e TZ=$(MY_TIME_ZONE) \
 		-v $(DOCKER_VOLUME_NAME):/config \
@@ -170,3 +169,4 @@ log:
 	@hzn service log -f $(SERVICE_NAME)
 
 .PHONY: default stop init run dev test clean build push attach browse publish publish-service publish-service-policy publish-deployment-policy publish-pattern agent-run distclean deploy-check check log remove-deployment-policy remove-service-policy remove-service
+

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The Makefile includes several targets to assist you in inspecting what is happen
 
 `make attach` to connect to the running container and open a shell inside it.
 
+> **Note** The service-homeassistant container by default runs in un-privileged mode, but it may require privileged conditions in certain cases (For eg: to detect specific hardware, for more information please ref. https://github.com/home-assistant/home-assistant.io/issues/18014). In that case you can manually add "--privileged" flag in the Makefile under `docker-run` command.
 ### All Makefile targets
 
 * `default` - init run browse


### PR DESCRIPTION
closes: #6  